### PR TITLE
Move SlackMessage up to be injected to the SlackNotifierCommand

### DIFF
--- a/examples/using-dot-env.php
+++ b/examples/using-dot-env.php
@@ -13,6 +13,7 @@ use Chemaclass\ScrumMaster\Command\SlackNotifierInput;
 use Chemaclass\ScrumMaster\Command\SlackNotifierOutput;
 use Chemaclass\ScrumMaster\Jira\JiraHttpClient;
 use Chemaclass\ScrumMaster\Slack\SlackHttpClient;
+use Chemaclass\ScrumMaster\Slack\MessageTemplate\SlackMessage;
 use Symfony\Component\HttpClient\HttpClient;
 
 $dotEnv = Dotenv\Dotenv::create(dirname(__DIR__));
@@ -32,7 +33,8 @@ $command = new SlackNotifierCommand(
     ])),
     new SlackHttpClient(HttpClient::create([
         'auth_bearer' => getenv('SLACK_BOT_USER_OAUTH_ACCESS_TOKEN'),
-    ]))
+    ])),
+    SlackMessage::withTimeToDiff(new DateTimeImmutable())
 );
 
 $command->execute(

--- a/src/ScrumMaster/Command/SlackNotifierCommand.php
+++ b/src/ScrumMaster/Command/SlackNotifierCommand.php
@@ -9,12 +9,11 @@ use Chemaclass\ScrumMaster\Jira\JiraHttpClient;
 use Chemaclass\ScrumMaster\Jira\JqlUrlBuilder;
 use Chemaclass\ScrumMaster\Jira\JqlUrlFactory;
 use Chemaclass\ScrumMaster\Jira\ReadModel\Company;
+use Chemaclass\ScrumMaster\Slack\MessageTemplate\MessageGeneratorInterface;
 use Chemaclass\ScrumMaster\Slack\SlackHttpClient;
 use Chemaclass\ScrumMaster\Slack\SlackMapping;
-use Chemaclass\ScrumMaster\Slack\SlackMessage;
 use Chemaclass\ScrumMaster\Slack\SlackNotifier;
 use Chemaclass\ScrumMaster\Slack\SlackNotifierResult;
-use DateTimeImmutable;
 
 final class SlackNotifierCommand
 {
@@ -24,10 +23,17 @@ final class SlackNotifierCommand
     /** @var SlackHttpClient */
     private $slackHttpClient;
 
-    public function __construct(JiraHttpClient $jiraHttpClient, SlackHttpClient $slackHttpClient)
-    {
+    /** @var MessageGeneratorInterface */
+    private $messageGenerator;
+
+    public function __construct(
+        JiraHttpClient $jiraHttpClient,
+        SlackHttpClient $slackHttpClient,
+        MessageGeneratorInterface $messageGenerator
+    ) {
         $this->jiraHttpClient = $jiraHttpClient;
         $this->slackHttpClient = $slackHttpClient;
+        $this->messageGenerator = $messageGenerator;
     }
 
     public function execute(SlackNotifierInput $input, SlackNotifierOutput $output): SlackNotifierResult
@@ -41,7 +47,7 @@ final class SlackNotifierCommand
             $company,
             new JqlUrlFactory($jiraBoard, JqlUrlBuilder::inOpenSprints($company)),
             SlackMapping::jiraNameWithSlackId($input->slackMappingIds()),
-            SlackMessage::withTimeToDiff(new DateTimeImmutable()),
+            $this->messageGenerator,
             $input->jiraUsersToIgnore()
         );
 

--- a/src/ScrumMaster/Slack/MessageTemplate/MessageGeneratorInterface.php
+++ b/src/ScrumMaster/Slack/MessageTemplate/MessageGeneratorInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Chemaclass\ScrumMaster\Slack;
+namespace Chemaclass\ScrumMaster\Slack\MessageTemplate;
 
 use Chemaclass\ScrumMaster\Jira\ReadModel\JiraTicket;
 

--- a/src/ScrumMaster/Slack/MessageTemplate/SlackMessage.php
+++ b/src/ScrumMaster/Slack/MessageTemplate/SlackMessage.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Chemaclass\ScrumMaster\Slack;
+namespace Chemaclass\ScrumMaster\Slack\MessageTemplate;
 
 use Chemaclass\ScrumMaster\Jira\ReadModel\Assignee;
 use Chemaclass\ScrumMaster\Jira\ReadModel\JiraTicket;

--- a/src/ScrumMaster/Slack/SlackNotifier.php
+++ b/src/ScrumMaster/Slack/SlackNotifier.php
@@ -10,6 +10,7 @@ use Chemaclass\ScrumMaster\Jira\ReadModel\Assignee;
 use Chemaclass\ScrumMaster\Jira\ReadModel\Company;
 use Chemaclass\ScrumMaster\Jira\ReadModel\JiraTicket;
 use Chemaclass\ScrumMaster\Jira\UrlFactoryInterface;
+use Chemaclass\ScrumMaster\Slack\MessageTemplate\MessageGeneratorInterface;
 use Chemaclass\ScrumMaster\Slack\ReadModel\SlackTicket;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 

--- a/tests/ScrumMasterTest/Unit/Slack/SlackMessageTest.php
+++ b/tests/ScrumMasterTest/Unit/Slack/SlackMessageTest.php
@@ -7,7 +7,7 @@ namespace Chemaclass\ScrumMasterTests\Unit\Slack;
 use Chemaclass\ScrumMaster\Jira\ReadModel\Assignee;
 use Chemaclass\ScrumMaster\Jira\ReadModel\JiraTicket;
 use Chemaclass\ScrumMaster\Jira\ReadModel\TicketStatus;
-use Chemaclass\ScrumMaster\Slack\SlackMessage;
+use Chemaclass\ScrumMaster\Slack\MessageTemplate\SlackMessage;
 use DateTimeImmutable;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
In order to add flexibility to the command, we should inject to `SlackNotifierCommand` the `MessageGeneratorInterface` with the message that the client wants to send via the notification channel.