### PR TITLE
Split the `Output` from the Command

### DIFF
--- a/examples/using-dot-env/app.php
+++ b/examples/using-dot-env/app.php
@@ -50,7 +50,6 @@ $command = new NotifierCommand(
     ]
 );
 
-$command->execute(
-    NotifierInput::fromArray($_ENV),
-    new NotifierOutput(new EchoOutput())
-);
+$result = $command->execute(NotifierInput::fromArray($_ENV));
+$output = new NotifierOutput(new EchoOutput());
+$output->write($result);

--- a/src/ScrumMaster/Channel/ChannelInterface.php
+++ b/src/ScrumMaster/Channel/ChannelInterface.php
@@ -11,8 +11,6 @@ use Chemaclass\ScrumMaster\Jira\ReadModel\Company;
 
 interface ChannelInterface
 {
-    public static function name(): string;
-
     public function sendNotifications(
         Board $board,
         JiraHttpClient $jiraClient,

--- a/src/ScrumMaster/Command/NotifierCommand.php
+++ b/src/ScrumMaster/Command/NotifierCommand.php
@@ -25,14 +25,14 @@ final class NotifierCommand
         $this->channels = $channels;
     }
 
-    public function execute(NotifierInput $input, NotifierOutput $output): array
+    public function execute(NotifierInput $input): array
     {
         $jiraBoard = new Board($input->daysForStatus());
         $company = Company::withNameAndProject($input->companyName(), $input->jiraProjectName());
         $result = [];
 
         foreach ($this->channels as $channel) {
-            $result[$channel->name()] = $channel->sendNotifications(
+            $result[get_class($channel)] = $channel->sendNotifications(
                 $jiraBoard,
                 $this->jiraHttpClient,
                 $company,
@@ -40,8 +40,6 @@ final class NotifierCommand
                 $input->jiraUsersToIgnore()
             );
         }
-
-        $output->write($result);
 
         return $result;
     }

--- a/src/ScrumMaster/Command/NotifierOutput.php
+++ b/src/ScrumMaster/Command/NotifierOutput.php
@@ -20,7 +20,7 @@ final class NotifierOutput
         $this->output = $output;
     }
 
-    /** @param ChannelResultInterface[] $results */
+    /** @param array<string,ChannelResultInterface> $results */
     public function write(array $results): void
     {
         foreach ($results as $channelName => $result) {
@@ -68,9 +68,12 @@ final class NotifierOutput
 
     private function buildNotificationFailed(ChannelResultInterface $result): string
     {
-        $notificationFailed = array_keys(array_filter($result->channelIssues(), function (ChannelIssue $slackTicket) {
-            return self::HTTP_OK !== $slackTicket->responseStatusCode();
-        }));
+        $notificationFailed = array_keys(array_filter(
+            $result->channelIssues(),
+            function (ChannelIssue $slackTicket) {
+                return self::HTTP_OK !== $slackTicket->responseStatusCode();
+            }
+        ));
 
         return implode(', ', $notificationFailed);
     }

--- a/src/ScrumMaster/Slack/SlackChannel.php
+++ b/src/ScrumMaster/Slack/SlackChannel.php
@@ -25,11 +25,6 @@ final class SlackChannel implements ChannelInterface
     /** @var MessageGeneratorInterface */
     private $messageGenerator;
 
-    public static function name(): string
-    {
-        return 'SlackChannel';
-    }
-
     public function __construct(
         SlackHttpClient $slackClient,
         SlackMapping $slackMapping,

--- a/tests/ScrumMasterTest/Unit/Command/NotifierCommandTest.php
+++ b/tests/ScrumMasterTest/Unit/Command/NotifierCommandTest.php
@@ -6,7 +6,6 @@ namespace Chemaclass\ScrumMasterTests\Unit\Command;
 
 use Chemaclass\ScrumMaster\Command\NotifierCommand;
 use Chemaclass\ScrumMaster\Command\NotifierInput;
-use Chemaclass\ScrumMaster\Command\NotifierOutput;
 use Chemaclass\ScrumMaster\Jira\JiraHttpClient;
 use Chemaclass\ScrumMaster\Slack\MessageTemplate\SlackMessage;
 use Chemaclass\ScrumMaster\Slack\SlackChannel;
@@ -31,8 +30,8 @@ final class NotifierCommandTest extends TestCase
     public function zeroNotificationsWereSent(): void
     {
         $command = $this->slackNotifierCommandWithJiraTickets([]);
-        $result = $command->execute($this->notifierInput(), $this->inMemoryOutput());
-        $this->assertEmpty($result[SlackChannel::name()]->channelIssues());
+        $result = $command->execute($this->notifierInput());
+        $this->assertEmpty($result[SlackChannel::class]->channelIssues());
     }
 
     /** @test */
@@ -43,11 +42,8 @@ final class NotifierCommandTest extends TestCase
             $this->createAnIssueAsArray('user.2.jira', 'KEY-222'),
         ]);
 
-        $inMemoryOutput = new InMemoryOutput();
-        $result = $command->execute($this->notifierInput(), new NotifierOutput($inMemoryOutput));
-
-        $this->assertNotEmpty($inMemoryOutput->lines());
-        $this->assertEquals(['KEY-111', 'KEY-222'], $result[SlackChannel::name()]->ticketKeys());
+        $result = $command->execute($this->notifierInput());
+        $this->assertEquals(['KEY-111', 'KEY-222'], $result[SlackChannel::class]->ticketKeys());
     }
 
     /** @test */
@@ -58,27 +54,18 @@ final class NotifierCommandTest extends TestCase
             $this->createAnIssueAsArray('user.2.jira', 'KEY-222'),
         ]);
 
-        $inMemoryOutput = new InMemoryOutput();
-
         $result = $command->execute(
             $this->notifierInput([
                 NotifierInput::JIRA_USERS_TO_IGNORE => '["user.1.jira"]',
-            ]),
-            new NotifierOutput($inMemoryOutput)
+            ])
         );
 
-        $this->assertNotEmpty($inMemoryOutput->lines());
-        $this->assertEquals(['KEY-222'], $result[SlackChannel::name()]->ticketKeys());
+        $this->assertEquals(['KEY-222'], $result[SlackChannel::class]->ticketKeys());
     }
 
     private function notifierInput(array $optionalFields = []): NotifierInput
     {
         return NotifierInput::fromArray(array_merge(self::MANDATORY_FIELDS, $optionalFields));
-    }
-
-    private function inMemoryOutput(): NotifierOutput
-    {
-        return new NotifierOutput(new InMemoryOutput());
     }
 
     private function slackNotifierCommandWithJiraTickets(array $jiraIssues): NotifierCommand


### PR DESCRIPTION
I removed the second parameter (`NotifierOutput`) from the `Command::execute()` function.

The rendering (output) should be independent of the execution (Command/Query principle).