### PR TITLE
Move command to root

### DIFF
--- a/examples/using-email-channel/app.php
+++ b/examples/using-email-channel/app.php
@@ -8,11 +8,11 @@ declare(strict_types=1);
 require dirname(__DIR__) . '/../vendor/autoload.php';
 
 use Chemaclass\ScrumMaster\Channel\Email;
-use Chemaclass\ScrumMaster\Command\IO\EchoOutput;
-use Chemaclass\ScrumMaster\Command\NotifierCommand;
-use Chemaclass\ScrumMaster\Command\NotifierInput;
-use Chemaclass\ScrumMaster\Command\NotifierOutput;
+use Chemaclass\ScrumMaster\IO\EchoOutput;
+use Chemaclass\ScrumMaster\IO\NotifierInput;
+use Chemaclass\ScrumMaster\IO\NotifierOutput;
 use Chemaclass\ScrumMaster\Jira\JiraHttpClient;
+use Chemaclass\ScrumMaster\Notifier;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\Mailer\Bridge\Google\Transport\GmailSmtpTransport;
 use Symfony\Component\Mailer\Mailer;
@@ -38,7 +38,7 @@ foreach ($mandatoryKeys as $mandatoryKey) {
     }
 }
 
-$notifier = new NotifierCommand(
+$notifier = new Notifier(
     new JiraHttpClient(HttpClient::create([
         'auth_basic' => [getenv('JIRA_API_LABEL'), getenv('JIRA_API_PASSWORD')],
     ])),
@@ -51,7 +51,7 @@ $notifier = new NotifierCommand(
     ]
 );
 
-$result = $notifier->execute(NotifierInput::new(
+$result = $notifier(NotifierInput::new(
     $_ENV[NotifierInput::COMPANY_NAME],
     $_ENV[NotifierInput::JIRA_PROJECT_NAME],
     json_decode($_ENV[NotifierInput::DAYS_FOR_STATUS], true),

--- a/examples/using-email-channel/app.php
+++ b/examples/using-email-channel/app.php
@@ -51,7 +51,7 @@ $notifier = new Notifier(
     ]
 );
 
-$result = $notifier(NotifierInput::new(
+$result = $notifier->notify(NotifierInput::new(
     $_ENV[NotifierInput::COMPANY_NAME],
     $_ENV[NotifierInput::JIRA_PROJECT_NAME],
     json_decode($_ENV[NotifierInput::DAYS_FOR_STATUS], true),

--- a/examples/using-slack-channel/app.php
+++ b/examples/using-slack-channel/app.php
@@ -8,11 +8,11 @@ declare(strict_types=1);
 require dirname(__DIR__) . '/../vendor/autoload.php';
 
 use Chemaclass\ScrumMaster\Channel\Slack;
-use Chemaclass\ScrumMaster\Command\IO\EchoOutput;
-use Chemaclass\ScrumMaster\Command\NotifierCommand;
-use Chemaclass\ScrumMaster\Command\NotifierInput;
-use Chemaclass\ScrumMaster\Command\NotifierOutput;
+use Chemaclass\ScrumMaster\IO\EchoOutput;
+use Chemaclass\ScrumMaster\IO\NotifierInput;
+use Chemaclass\ScrumMaster\IO\NotifierOutput;
 use Chemaclass\ScrumMaster\Jira\JiraHttpClient;
+use Chemaclass\ScrumMaster\Notifier;
 use Symfony\Component\HttpClient\HttpClient;
 
 $dotEnv = Dotenv\Dotenv::create(__DIR__);
@@ -36,7 +36,7 @@ foreach ($mandatoryKeys as $mandatoryKey) {
     }
 }
 
-$command = new NotifierCommand(
+$notifier = new Notifier(
     new JiraHttpClient(HttpClient::create([
         'auth_basic' => [getenv('JIRA_API_LABEL'), getenv('JIRA_API_PASSWORD')],
     ])),
@@ -51,7 +51,7 @@ $command = new NotifierCommand(
     ]
 );
 
-$result = $command->execute(NotifierInput::new(
+$result = $notifier(NotifierInput::new(
     $_ENV[NotifierInput::COMPANY_NAME],
     $_ENV[NotifierInput::JIRA_PROJECT_NAME],
     json_decode($_ENV[NotifierInput::DAYS_FOR_STATUS], true),

--- a/examples/using-slack-channel/app.php
+++ b/examples/using-slack-channel/app.php
@@ -51,7 +51,7 @@ $notifier = new Notifier(
     ]
 );
 
-$result = $notifier(NotifierInput::new(
+$result = $notifier->notify(NotifierInput::new(
     $_ENV[NotifierInput::COMPANY_NAME],
     $_ENV[NotifierInput::JIRA_PROJECT_NAME],
     json_decode($_ENV[NotifierInput::DAYS_FOR_STATUS], true),

--- a/src/ScrumMaster/IO/EchoOutput.php
+++ b/src/ScrumMaster/IO/EchoOutput.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Chemaclass\ScrumMaster\Command\IO;
+namespace Chemaclass\ScrumMaster\IO;
 
 final class EchoOutput implements OutputInterface
 {

--- a/src/ScrumMaster/IO/NotifierInput.php
+++ b/src/ScrumMaster/IO/NotifierInput.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Chemaclass\ScrumMaster\Command;
+namespace Chemaclass\ScrumMaster\IO;
 
 final class NotifierInput
 {

--- a/src/ScrumMaster/IO/NotifierOutput.php
+++ b/src/ScrumMaster/IO/NotifierOutput.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Chemaclass\ScrumMaster\Command;
+namespace Chemaclass\ScrumMaster\IO;
 
 use Chemaclass\ScrumMaster\Channel\ChannelResult;
 use Chemaclass\ScrumMaster\Channel\ReadModel\ChannelIssue;
-use Chemaclass\ScrumMaster\Command\IO\OutputInterface;
+use Chemaclass\ScrumMaster\IO\OutputInterface;
 use Chemaclass\ScrumMaster\Common\Request;
 
 final class NotifierOutput

--- a/src/ScrumMaster/IO/OutputInterface.php
+++ b/src/ScrumMaster/IO/OutputInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Chemaclass\ScrumMaster\Command\IO;
+namespace Chemaclass\ScrumMaster\IO;
 
 interface OutputInterface
 {

--- a/src/ScrumMaster/Notifier.php
+++ b/src/ScrumMaster/Notifier.php
@@ -28,7 +28,7 @@ final class Notifier
     }
 
     /** @return array<string,ChannelResult> */
-    public function __invoke(NotifierInput $input): array
+    public function notify(NotifierInput $input): array
     {
         $jiraBoard = new Board($input->daysForStatus());
         $company = Company::withNameAndProject($input->companyName(), $input->jiraProjectName());

--- a/src/ScrumMaster/Notifier.php
+++ b/src/ScrumMaster/Notifier.php
@@ -2,17 +2,18 @@
 
 declare(strict_types=1);
 
-namespace Chemaclass\ScrumMaster\Command;
+namespace Chemaclass\ScrumMaster;
 
 use Chemaclass\ScrumMaster\Channel\ChannelInterface;
 use Chemaclass\ScrumMaster\Channel\ChannelResult;
+use Chemaclass\ScrumMaster\IO\NotifierInput;
 use Chemaclass\ScrumMaster\Jira\Board;
 use Chemaclass\ScrumMaster\Jira\JiraHttpClient;
 use Chemaclass\ScrumMaster\Jira\JqlUrlBuilder;
 use Chemaclass\ScrumMaster\Jira\JqlUrlFactory;
 use Chemaclass\ScrumMaster\Jira\ReadModel\Company;
 
-final class NotifierCommand
+final class Notifier
 {
     /** @var JiraHttpClient */
     private $jiraHttpClient;
@@ -27,7 +28,7 @@ final class NotifierCommand
     }
 
     /** @return array<string,ChannelResult> */
-    public function execute(NotifierInput $input): array
+    public function __invoke(NotifierInput $input): array
     {
         $jiraBoard = new Board($input->daysForStatus());
         $company = Company::withNameAndProject($input->companyName(), $input->jiraProjectName());

--- a/tests/ScrumMasterTest/Functional/EmailNotifierCommandTest.php
+++ b/tests/ScrumMasterTest/Functional/EmailNotifierCommandTest.php
@@ -31,7 +31,7 @@ final class EmailNotifierCommandTest extends TestCase
     public function zeroNotificationsWereSent(): void
     {
         $notifier = $this->slackNotifierCommandWithJiraTickets([]);
-        $result = $notifier($this->notifierInput());
+        $result = $notifier->notify($this->notifierInput());
         /** @var ChannelResult $channelResult */
         $channelResult = $result[Email\Channel::class];
         $this->assertEmpty($channelResult->channelIssues());
@@ -45,7 +45,7 @@ final class EmailNotifierCommandTest extends TestCase
             $this->createAJiraIssueAsArray('user.2.jira', 'KEY-222'),
         ]);
 
-        $result = $notifier($this->notifierInput());
+        $result = $notifier->notify($this->notifierInput());
         /** @var ChannelResult $channelResult */
         $channelResult = $result[Email\Channel::class];
         $this->assertEquals(['KEY-111', 'KEY-222'], array_keys($channelResult->channelIssues()));
@@ -59,7 +59,7 @@ final class EmailNotifierCommandTest extends TestCase
             $this->createAJiraIssueAsArray('user.2.jira', 'KEY-222'),
         ]);
 
-        $result = $notifier(
+        $result = $notifier->notify(
             $this->notifierInput($usersToIgnore = ['user.1.jira'])
         );
 
@@ -99,7 +99,7 @@ final class EmailNotifierCommandTest extends TestCase
             ]
         );
 
-        $notifier($this->notifierInput());
+        $notifier->notify($this->notifierInput());
     }
 
     /** @test */
@@ -125,7 +125,7 @@ final class EmailNotifierCommandTest extends TestCase
             ]
         );
 
-        $results = $notifier($this->notifierInput());
+        $results = $notifier->notify($this->notifierInput());
         /** @var ChannelResult $channelResult */
         $channelResult = $results[Email\Channel::class];
         /** @var ChannelIssue $issue */
@@ -155,7 +155,7 @@ final class EmailNotifierCommandTest extends TestCase
             ]
         );
 
-        $notifier($this->notifierInput());
+        $notifier->notify($this->notifierInput());
     }
 
     private function notifierInput(array $jiraUsersToIgnore = []): NotifierInput

--- a/tests/ScrumMasterTest/Functional/SlackNotifierCommandTest.php
+++ b/tests/ScrumMasterTest/Functional/SlackNotifierCommandTest.php
@@ -6,8 +6,8 @@ namespace Chemaclass\ScrumMasterTests\Functional;
 
 use Chemaclass\ScrumMaster\Channel\ChannelResult;
 use Chemaclass\ScrumMaster\Channel\Slack;
-use Chemaclass\ScrumMaster\Command\NotifierCommand;
-use Chemaclass\ScrumMaster\Command\NotifierInput;
+use Chemaclass\ScrumMaster\Notifier;
+use Chemaclass\ScrumMaster\IO\NotifierInput;
 use Chemaclass\ScrumMaster\Jira\JiraHttpClient;
 use Chemaclass\ScrumMasterTests\Unit\Concerns\JiraApiResource;
 use DateTimeImmutable;
@@ -27,8 +27,8 @@ final class SlackNotifierCommandTest extends TestCase
     /** @test */
     public function zeroNotificationsWereSent(): void
     {
-        $command = $this->slackNotifierCommandWithJiraTickets([]);
-        $result = $command->execute($this->notifierInput());
+        $notifier = $this->slackNotifierCommandWithJiraTickets([]);
+        $result = $notifier($this->notifierInput());
         /** @var ChannelResult $channelResult */
         $channelResult = $result[Slack\Channel::class];
         $this->assertEmpty($channelResult->channelIssues());
@@ -37,12 +37,12 @@ final class SlackNotifierCommandTest extends TestCase
     /** @test */
     public function twoSuccessfulNotificationsWereSent(): void
     {
-        $command = $this->slackNotifierCommandWithJiraTickets([
+        $notifier = $this->slackNotifierCommandWithJiraTickets([
             $this->createAJiraIssueAsArray('user.1.jira', 'KEY-111'),
             $this->createAJiraIssueAsArray('user.2.jira', 'KEY-222'),
         ]);
 
-        $result = $command->execute($this->notifierInput());
+        $result = $notifier($this->notifierInput());
         /** @var ChannelResult $channelResult */
         $channelResult = $result[Slack\Channel::class];
         $this->assertEquals(['KEY-111', 'KEY-222'], array_keys($channelResult->channelIssues()));
@@ -51,14 +51,12 @@ final class SlackNotifierCommandTest extends TestCase
     /** @test */
     public function ignoredUserShouldNotReceiveAnyNotification(): void
     {
-        $command = $this->slackNotifierCommandWithJiraTickets([
+        $notifier = $this->slackNotifierCommandWithJiraTickets([
             $this->createAJiraIssueAsArray('user.1.jira', 'KEY-111'),
             $this->createAJiraIssueAsArray('user.2.jira', 'KEY-222'),
         ]);
 
-        $result = $command->execute(
-            $this->notifierInput($usersToIgnore = ['user.1.jira'])
-        );
+        $result = $notifier($this->notifierInput($usersToIgnore = ['user.1.jira']));
 
         /** @var ChannelResult $channelResult */
         $channelResult = $result[Slack\Channel::class];
@@ -70,9 +68,9 @@ final class SlackNotifierCommandTest extends TestCase
         return NotifierInput::new('company.name', 'Jira project name', ['status' => 1], $jiraUsersToIgnore);
     }
 
-    private function slackNotifierCommandWithJiraTickets(array $jiraIssues): NotifierCommand
+    private function slackNotifierCommandWithJiraTickets(array $jiraIssues): Notifier
     {
-        return new NotifierCommand(
+        return new Notifier(
             new JiraHttpClient($this->mockJiraClient($jiraIssues)),
             [
                 new Slack\Channel(

--- a/tests/ScrumMasterTest/Functional/SlackNotifierCommandTest.php
+++ b/tests/ScrumMasterTest/Functional/SlackNotifierCommandTest.php
@@ -28,7 +28,7 @@ final class SlackNotifierCommandTest extends TestCase
     public function zeroNotificationsWereSent(): void
     {
         $notifier = $this->slackNotifierCommandWithJiraTickets([]);
-        $result = $notifier($this->notifierInput());
+        $result = $notifier->notify($this->notifierInput());
         /** @var ChannelResult $channelResult */
         $channelResult = $result[Slack\Channel::class];
         $this->assertEmpty($channelResult->channelIssues());
@@ -42,7 +42,7 @@ final class SlackNotifierCommandTest extends TestCase
             $this->createAJiraIssueAsArray('user.2.jira', 'KEY-222'),
         ]);
 
-        $result = $notifier($this->notifierInput());
+        $result = $notifier->notify($this->notifierInput());
         /** @var ChannelResult $channelResult */
         $channelResult = $result[Slack\Channel::class];
         $this->assertEquals(['KEY-111', 'KEY-222'], array_keys($channelResult->channelIssues()));
@@ -56,7 +56,7 @@ final class SlackNotifierCommandTest extends TestCase
             $this->createAJiraIssueAsArray('user.2.jira', 'KEY-222'),
         ]);
 
-        $result = $notifier($this->notifierInput($usersToIgnore = ['user.1.jira']));
+        $result = $notifier->notify($this->notifierInput($usersToIgnore = ['user.1.jira']));
 
         /** @var ChannelResult $channelResult */
         $channelResult = $result[Slack\Channel::class];

--- a/tests/ScrumMasterTest/Unit/IO/EchoOutputTest.php
+++ b/tests/ScrumMasterTest/Unit/IO/EchoOutputTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Chemaclass\ScrumMasterTests\Unit\Command\IO;
+namespace Chemaclass\ScrumMasterTests\Unit\IO;
 
-use Chemaclass\ScrumMaster\Command\IO\EchoOutput;
+use Chemaclass\ScrumMaster\IO\EchoOutput;
 use PHPUnit\Framework\TestCase;
 
 class EchoOutputTest extends TestCase

--- a/tests/ScrumMasterTest/Unit/IO/NotifierOutputTest.php
+++ b/tests/ScrumMasterTest/Unit/IO/NotifierOutputTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Chemaclass\ScrumMasterTests\Unit\Command;
+namespace Chemaclass\ScrumMasterTests\Unit\IO;
 
 use Chemaclass\ScrumMaster\Channel\ChannelResult;
 use Chemaclass\ScrumMaster\Channel\ReadModel\ChannelIssue;
-use Chemaclass\ScrumMaster\Command\IO\OutputInterface;
-use Chemaclass\ScrumMaster\Command\NotifierOutput;
+use Chemaclass\ScrumMaster\IO\OutputInterface;
+use Chemaclass\ScrumMaster\IO\NotifierOutput;
 use PHPUnit\Framework\TestCase;
 
 final class NotifierOutputTest extends TestCase

--- a/tests/ScrumMasterTest/Unit/NotifierTest.php
+++ b/tests/ScrumMasterTest/Unit/NotifierTest.php
@@ -22,7 +22,7 @@ final class NotifierTest extends TestCase
     public function zeroNotificationsWereSent(): void
     {
         $notifier = $this->notifierCommandWithChannelIssues([]);
-        $result = $notifier($this->notifierInput());
+        $result = $notifier->notify($this->notifierInput());
         /** @var ChannelResult $channelResult */
         $channelResult = reset($result);
         $this->assertEmpty($channelResult->channelIssues());
@@ -37,7 +37,7 @@ final class NotifierTest extends TestCase
         ];
 
         $notifier = $this->notifierCommandWithChannelIssues($issues);
-        $result = $notifier($this->notifierInput());
+        $result = $notifier->notify($this->notifierInput());
         /** @var ChannelResult $channelResult */
         $channelResult = reset($result);
         $this->assertEquals($issues, $channelResult->channelIssues());

--- a/tests/ScrumMasterTest/Unit/NotifierTest.php
+++ b/tests/ScrumMasterTest/Unit/NotifierTest.php
@@ -7,22 +7,22 @@ namespace Chemaclass\ScrumMasterTests\Unit\Command;
 use Chemaclass\ScrumMaster\Channel\ChannelInterface;
 use Chemaclass\ScrumMaster\Channel\ChannelResult;
 use Chemaclass\ScrumMaster\Channel\ReadModel\ChannelIssue;
-use Chemaclass\ScrumMaster\Command\NotifierCommand;
-use Chemaclass\ScrumMaster\Command\NotifierInput;
+use Chemaclass\ScrumMaster\Notifier;
+use Chemaclass\ScrumMaster\IO\NotifierInput;
 use Chemaclass\ScrumMaster\Jira\JiraHttpClient;
 use Chemaclass\ScrumMasterTests\Unit\Concerns\JiraApiResource;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
-final class NotifierCommandTest extends TestCase
+final class NotifierTest extends TestCase
 {
     use JiraApiResource;
 
     /** @test */
     public function zeroNotificationsWereSent(): void
     {
-        $command = $this->notifierCommandWithChannelIssues([]);
-        $result = $command->execute($this->notifierInput());
+        $notifier = $this->notifierCommandWithChannelIssues([]);
+        $result = $notifier($this->notifierInput());
         /** @var ChannelResult $channelResult */
         $channelResult = reset($result);
         $this->assertEmpty($channelResult->channelIssues());
@@ -36,8 +36,8 @@ final class NotifierCommandTest extends TestCase
             'KEY-2' => ChannelIssue::withCodeAndAssignee(200, 'jira.user.2'),
         ];
 
-        $command = $this->notifierCommandWithChannelIssues($issues);
-        $result = $command->execute($this->notifierInput());
+        $notifier = $this->notifierCommandWithChannelIssues($issues);
+        $result = $notifier($this->notifierInput());
         /** @var ChannelResult $channelResult */
         $channelResult = reset($result);
         $this->assertEquals($issues, $channelResult->channelIssues());
@@ -48,13 +48,13 @@ final class NotifierCommandTest extends TestCase
         return NotifierInput::new('company.name', 'Jira project name', ['status' => 1]);
     }
 
-    private function notifierCommandWithChannelIssues(array $channelIssues): NotifierCommand
+    private function notifierCommandWithChannelIssues(array $channelIssues): Notifier
     {
         /** @var ChannelInterface|MockObject $channel */
         $channel = $this->createMock(ChannelInterface::class);
         $channel->method('sendNotifications')->willReturn(ChannelResult::withIssues($channelIssues));
 
-        return new NotifierCommand(
+        return new Notifier(
             new JiraHttpClient($this->mockJiraClient([])),
             [$channel]
         );


### PR DESCRIPTION
# Description

In order to keep simple the understanding of the entry point of this tool (and because there is no other purpose than the notifier itself) I decide to get rid of the `Command` directory and place the NotifierCommand in the root of the project

# Changes

- [x] Moved the `NotifierCommand` from `Command` directory to the root of the project
- [x] Rename `NotifierCommand` to `Notifier`