### PR TITLE
Refactor EnvKeys using DI to extract getenv() from its logic

### DIFF
--- a/examples/using-all-channels/app.php
+++ b/examples/using-all-channels/app.php
@@ -24,8 +24,8 @@ use Symfony\Component\Mailer\Mailer;
 $dotEnv = Dotenv::create(__DIR__);
 $dotEnv->load();
 
-$mandatoryKeys = EnvKeys::fromFile(file_get_contents(__DIR__ . '/.env.dist'));
-$mandatoryKeys->validate();
+$mandatoryKeys = new EnvKeys(getenv());
+$mandatoryKeys->validate(file_get_contents(__DIR__ . '/.env.dist'));
 
 $jiraHttpClient = new JiraHttpClient(HttpClient::create([
     'auth_basic' => [getenv('JIRA_API_LABEL'), getenv('JIRA_API_PASSWORD')],

--- a/examples/using-email-channel/app.php
+++ b/examples/using-email-channel/app.php
@@ -23,8 +23,8 @@ use Symfony\Component\Mailer\Mailer;
 $dotEnv = Dotenv::create(__DIR__);
 $dotEnv->load();
 
-$mandatoryKeys = EnvKeys::fromFile(file_get_contents(__DIR__ . '/.env.dist'));
-$mandatoryKeys->validate();
+$mandatoryKeys = new EnvKeys(getenv());
+$mandatoryKeys->validate(file_get_contents(__DIR__ . '/.env.dist'));
 
 $notifier = new Notifier(
     new JiraHttpClient(HttpClient::create([

--- a/examples/using-slack-channel/app.php
+++ b/examples/using-slack-channel/app.php
@@ -20,8 +20,8 @@ use Symfony\Component\HttpClient\HttpClient;
 $dotEnv = Dotenv::create(__DIR__);
 $dotEnv->load();
 
-$mandatoryKeys = EnvKeys::fromFile(file_get_contents(__DIR__ . '/.env.dist'));
-$mandatoryKeys->validate();
+$mandatoryKeys = new EnvKeys(getenv());
+$mandatoryKeys->validate(file_get_contents(__DIR__ . '/.env.dist'));
 
 $notifier = new Notifier(
     new JiraHttpClient(HttpClient::create([

--- a/src/ScrumMaster/Common/EnvKeys.php
+++ b/src/ScrumMaster/Common/EnvKeys.php
@@ -4,50 +4,53 @@ declare(strict_types=1);
 
 namespace Chemaclass\ScrumMaster\Common;
 
+use Chemaclass\ScrumMaster\Common\Exception\MissingKeysException;
+
 final class EnvKeys
 {
     /** @var array */
-    private $keys = [];
+    private $envVars;
 
-    public static function fromFile(string $content): self
+    public function __construct(array $envVars)
     {
-        $self = new self();
-
-        foreach (explode(PHP_EOL, $content) as $line) {
-            if ($line && !static::isAComment($line)) {
-                $self->keys[] = static::getKeyFromLine($line);
-            }
-        }
-
-        return $self;
+        $this->envVars = $envVars;
     }
 
-    public function keys(): array
+    public function validate(string $content): void
     {
-        return $this->keys;
-    }
-
-    public function validate(): void
-    {
+        $lines = explode(PHP_EOL, $content);
         $missingKeys = [];
 
-        foreach ($this->keys as $key) {
-            if (false === getenv($key)) {
+        foreach ($this->keys($lines) as $key) {
+            if (!isset($this->envVars[$key])) {
                 $missingKeys[] = $key;
             }
         }
 
         if ($missingKeys) {
-            throw new \Exception(implode(', ', $missingKeys) . ' keys are mandatory but missing!');
+            throw new MissingKeysException($missingKeys);
         }
     }
 
-    private static function isAComment(string $line): bool
+    private function keys(array $lines): array
+    {
+        $keys = [];
+
+        foreach ($lines as $line) {
+            if ($line && !$this->isAComment($line)) {
+                $keys[] = $this->getKeyFromLine($line);
+            }
+        }
+
+        return $keys;
+    }
+
+    private function isAComment(string $line): bool
     {
         return 0 === mb_strpos($line, '#');
     }
 
-    private static function getKeyFromLine(string $line): string
+    private function getKeyFromLine(string $line): string
     {
         return mb_substr($line, 0, mb_strpos($line, '='));
     }

--- a/src/ScrumMaster/Common/Exception/MissingKeysException.php
+++ b/src/ScrumMaster/Common/Exception/MissingKeysException.php
@@ -6,7 +6,6 @@ namespace Chemaclass\ScrumMaster\Common\Exception;
 
 final class MissingKeysException extends \Exception
 {
-
     public function __construct(array $missingKeys)
     {
         parent::__construct(implode(', ', $missingKeys) . ' keys are mandatory but missing!');

--- a/src/ScrumMaster/Common/Exception/MissingKeysException.php
+++ b/src/ScrumMaster/Common/Exception/MissingKeysException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Chemaclass\ScrumMaster\Common\Exception;
+
+final class MissingKeysException extends \Exception
+{
+
+    public function __construct(array $missingKeys)
+    {
+        parent::__construct(implode(', ', $missingKeys) . ' keys are mandatory but missing!');
+    }
+}

--- a/tests/ScrumMasterTest/Unit/Common/EnvKeysTest.php
+++ b/tests/ScrumMasterTest/Unit/Common/EnvKeysTest.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Chemaclass\ScrumMasterTests\Unit\Common;
 
 use Chemaclass\ScrumMaster\Common\EnvKeys;
+use Chemaclass\ScrumMaster\Common\Exception\MissingKeysException;
 use PHPUnit\Framework\TestCase;
 
 final class EnvKeysTest extends TestCase
 {
     /** @test */
-    public function fromEnvFile(): void
+    public function valid(): void
     {
         $content = <<<ENV
 #A comment
@@ -19,13 +20,30 @@ KEY_2=null
 # Another comment
 KEY_3="true"
 KEY_4='[]'
-
 ENV;
-        self::assertEquals([
-            'KEY_1',
-            'KEY_2',
-            'KEY_3',
-            'KEY_4',
-        ], EnvKeys::fromFile($content)->keys());
+        $envKeys = new EnvKeys([
+            'KEY_1' => 'value1',
+            'KEY_2' => 'value2',
+            'KEY_3' => 'value3',
+            'KEY_4' => 'value4',
+        ]);
+        $envKeys->validate($content);
+        self::assertTrue(true);//No exception was thrown
+    }
+
+    /** @test */
+    public function invalid(): void
+    {
+        $content = <<<ENV
+#A comment
+KEY_1=~
+KEY_2=null
+# Another comment
+KEY_3="true"
+KEY_4='[]'
+ENV;
+        self::expectExceptionObject(new MissingKeysException(['KEY_3', 'KEY_4']));
+        $envKeys = new EnvKeys(['KEY_1' => 'value1', 'KEY_2' => 'value2']);
+        $envKeys->validate($content);
     }
 }


### PR DESCRIPTION
# Description

In order to unit test the `validate()` functionality from the `EnvKeys` class, I needed to extract (and inject via DI) the values from `getenv()`.