### PR TITLE
Bugfix in Tickets::fromJiraResponse()

### DIFF
--- a/src/ScrumMaster/Jira/Tickets.php
+++ b/src/ScrumMaster/Jira/Tickets.php
@@ -18,29 +18,46 @@ final class Tickets
     public static function fromJiraResponse(ResponseInterface $response): array
     {
         $jiraTickets = [];
-        $rawArray = $response->toArray();
 
-        foreach ($rawArray['issues'] ?? [] as $item) {
-            $fields = $item['fields'];
-            $assignee = $fields['assignee'];
-
-            $jiraTickets[] = new JiraTicket(
-                $fields['summary'],
-                $item['key'],
-                new TicketStatus(
-                    $fields['status']['name'],
-                    new DateTimeImmutable($fields['statuscategorychangedate'])
-                ),
-                new Assignee(
-                    $assignee['name'] ?? '',
-                    $assignee['key'] ?? '',
-                    $assignee['displayName'] ?? '',
-                    $assignee['emailAddress'] ?? ''
-                ),
-                $storyPoints = (int) $fields[self::FIELD_STORY_POINTS]
-            );
+        foreach ($response->toArray()['issues'] ?? [] as $item) {
+            $jiraTickets[] = static::newJiraTicket($item);
         }
 
         return $jiraTickets;
+    }
+
+    private static function newJiraTicket(array $item): JiraTicket
+    {
+        $fields = $item['fields'];
+
+        return new JiraTicket(
+            $fields['summary'],
+            $item['key'],
+            static::newTicketStatus($fields),
+            static::newAssignee($fields['assignee'] ?? []),
+            $storyPoints = (int) $fields[self::FIELD_STORY_POINTS]
+        );
+    }
+
+    private static function newTicketStatus(array $fields): TicketStatus
+    {
+        return new TicketStatus(
+            $fields['status']['name'],
+            new DateTimeImmutable($fields['statuscategorychangedate'])
+        );
+    }
+
+    private static function newAssignee(array $assignee): Assignee
+    {
+        if (empty($assignee)) {
+            return Assignee::empty();
+        }
+
+        return new Assignee(
+            $assignee['name'],
+            $assignee['key'],
+            $assignee['displayName'],
+            $assignee['emailAddress']
+        );
     }
 }

--- a/src/ScrumMaster/Jira/Tickets.php
+++ b/src/ScrumMaster/Jira/Tickets.php
@@ -32,10 +32,10 @@ final class Tickets
                     new DateTimeImmutable($fields['statuscategorychangedate'])
                 ),
                 new Assignee(
-                    $assignee['name'],
-                    $assignee['key'],
-                    $assignee['displayName'],
-                    $assignee['emailAddress']
+                    $assignee['name'] ?? '',
+                    $assignee['key'] ?? '',
+                    $assignee['displayName'] ?? '',
+                    $assignee['emailAddress'] ?? ''
                 ),
                 $storyPoints = (int) $fields[self::FIELD_STORY_POINTS]
             );


### PR DESCRIPTION
# Description

I found a bug in the line `$assignee = $fields['assignee'];` that was giving `null` when nobody is assigned to a ticket.

The fix: `$fields['assignee'] ?? []`