### PR TITLE
Create email-template.twig

### DIFF
--- a/examples/templates/email-template.twig
+++ b/examples/templates/email-template.twig
@@ -1,0 +1,25 @@
+{% set firstTicket = tickets | first %}
+{% set assignee = firstTicket.assignee %}
+
+{% if assignee.key %}
+    {% set salutation = "Hey, " ~ assignee.displayName %}
+{% else %}
+    {% set salutation = 'Hey Team' %}
+{% endif %}
+
+<header> {{ salutation }}, please have a look</header>
+<hr>
+
+{% for ticket in tickets %}
+    {% set status = ticket.status %}
+    {% set daysDiff = status.changeDate.diff(now).days %}
+    {% set url = "https://" ~ companyName ~ ".atlassian.net/browse/" ~ ticket.key %}
+    {% set dayWord = (daysDiff > 1) ? 'days' : 'day' %}
+
+    <div class="ticket">
+        <b>Jira Ticket</b>: <a href='{{ url }}'>{{ ticket.key }}</a> - <i>{{ ticket.title }}</i> <br>
+        <b>Current status</b>: <i>{{ status.name }} </i> since {{ daysDiff }} {{ dayWord }}<br>
+        <b>Story Points</b>: {{ ticket.storyPoints }}<br>
+    </div>
+    <hr>
+{% endfor %}

--- a/examples/using-all-channels/console
+++ b/examples/using-all-channels/console
@@ -28,6 +28,8 @@ use Twig\Loader\FilesystemLoader;
 Dotenv::create(__DIR__)->load();
 EnvKeys::create((array)getenv())->validate(file_get_contents(__DIR__ . '/.env.dist'));
 
+$twig = new Environment(new FilesystemLoader('../templates'));
+
 $jiraHttpClient = new JiraHttpClient(HttpClient::create([
     'auth_basic' => [getenv('JIRA_API_LABEL'), getenv('JIRA_API_PASSWORD')],
 ]));
@@ -35,7 +37,7 @@ $jiraHttpClient = new JiraHttpClient(HttpClient::create([
 $channels = [
     new Email\Channel(
         new Mailer(new GmailSmtpTransport(getenv('MAILER_USERNAME'), getenv('MAILER_PASSWORD'))),
-        Email\MessageGenerator::beingNow(new DateTimeImmutable()),
+        new Email\MessageGenerator(new DateTimeImmutable(), $twig),
         new Email\AddressGenerator((new ByPassEmail())
             ->setSendEmailsToAssignee(false) // <- OverriddenEmails wont have no effect as long as this is false
             ->setOverriddenEmails(json_decode(getenv('OVERRIDDEN_EMAILS'), true))
@@ -62,5 +64,5 @@ $result = $notifier->notify(NotifierInput::new(
 
 (new NotifierOutput(
     new EchoOutput(),
-    new Environment(new FilesystemLoader('../templates'))
+    $twig
 ))->write($result, 'output/channel-result.twig');

--- a/examples/using-email-channel/console
+++ b/examples/using-email-channel/console
@@ -26,6 +26,8 @@ use Twig\Loader\FilesystemLoader;
 Dotenv::create(__DIR__)->load();
 EnvKeys::create((array) getenv())->validate(file_get_contents(__DIR__ . '/.env.dist'));
 
+$twig = new Environment(new FilesystemLoader('../templates'));
+
 $notifier = new Notifier(
     new JiraHttpClient(HttpClient::create([
         'auth_basic' => [getenv('JIRA_API_LABEL'), getenv('JIRA_API_PASSWORD')],
@@ -33,7 +35,7 @@ $notifier = new Notifier(
     $channels = [
         new Email\Channel(
             new Mailer(new GmailSmtpTransport(getenv('MAILER_USERNAME'), getenv('MAILER_PASSWORD'))),
-            Email\MessageGenerator::beingNow(new DateTimeImmutable()),
+            new Email\MessageGenerator(new DateTimeImmutable(), $twig),
             new Email\AddressGenerator((new ByPassEmail())
                 ->setSendEmailsToAssignee(false) // <- OverriddenEmails wont have effect as long as this is false
                 ->setOverriddenEmails(json_decode(getenv('OVERRIDDEN_EMAILS'), true))
@@ -51,5 +53,5 @@ $result = $notifier->notify(NotifierInput::new(
 
 (new NotifierOutput(
     new EchoOutput(),
-    new Environment(new FilesystemLoader('../templates'))
+    $twig
 ))->write($result, 'output/channel-result.twig');

--- a/src/ScrumMaster/Channel/Email/MessageGenerator.php
+++ b/src/ScrumMaster/Channel/Email/MessageGenerator.php
@@ -5,63 +5,29 @@ declare(strict_types=1);
 namespace Chemaclass\ScrumMaster\Channel\Email;
 
 use Chemaclass\ScrumMaster\Channel\MessageGeneratorInterface;
-use Chemaclass\ScrumMaster\Jira\ReadModel\Assignee;
-use Chemaclass\ScrumMaster\Jira\ReadModel\JiraTicket;
 use DateTimeImmutable;
+use Twig;
 
 final class MessageGenerator implements MessageGeneratorInterface
 {
     private DateTimeImmutable $now;
 
-    public static function beingNow(DateTimeImmutable $now): self
-    {
-        return new self($now);
-    }
+    private Twig\Environment $twig;
 
-    private function __construct(DateTimeImmutable $now)
+    public function __construct(DateTimeImmutable $now, Twig\Environment $twig)
     {
         $this->now = $now;
+        $this->twig = $twig;
     }
 
     public function forJiraTickets(array $tickets, string $companyName): string
     {
-        /** @var Assignee $assignee */
-        $assignee = $tickets[array_key_first($tickets)]->assignee();
-        $text = $this->headerText($assignee);
         uksort($tickets, 'strnatcasecmp');
 
-        foreach ($tickets as $ticket) {
-            $text .= $this->textForTicket($ticket, $companyName);
-        }
-
-        return $text;
-    }
-
-    private function textForTicket(JiraTicket $ticket, string $companyName): string
-    {
-        $status = $ticket->status();
-        $daysDiff = $status->changeDate()->diff($this->now)->days;
-        $url = "https://{$companyName}.atlassian.net/browse/{$ticket->key()}";
-        $dayWord = ($daysDiff > 1) ? 'days' : 'day';
-
-        return <<<TXT
-<div class="ticket">
-    <b>Jira Ticket</b>: <a href="{$url}">{$ticket->key()}</a> - <i>{$ticket->title()}</i> <br>
-    <b>Current status</b>: <i>{$status->name()}</i> since {$daysDiff} {$dayWord}<br>
-    <b>Story Points</b>: {$ticket->storyPoints()}<br>
-</div>
-<hr>
-TXT;
-    }
-
-    private function headerText(Assignee $assignee): string
-    {
-        if ($assignee->key()) {
-            $salutation = "Hey, {$assignee->displayName()} ({$assignee->name()})";
-        } else {
-            $salutation = 'Hey Team';
-        }
-
-        return '<header>' . $salutation . ', please have a look:</header><hr>';
+        return $this->twig->render('email-template.twig', [
+            'tickets' => $tickets,
+            'now' => $this->now,
+            'companyName' => $companyName,
+        ]);
     }
 }

--- a/tests/ScrumMasterTest/Functional/EmailNotifierCommandTest.php
+++ b/tests/ScrumMasterTest/Functional/EmailNotifierCommandTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\Mailer\Mailer;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email as SymfonyEmail;
+use Twig\Environment;
 
 final class EmailNotifierCommandTest extends TestCase
 {
@@ -91,7 +92,7 @@ final class EmailNotifierCommandTest extends TestCase
             [
                 new Channel(
                     new Mailer($transport),
-                    MessageGenerator::beingNow(new DateTimeImmutable()),
+                    $this->messageGenerator(),
                     new AddressGenerator((new ByPassEmail())->setOverriddenEmails([
                         'user.1.jira' => 'user.3@email.com',
                         'user.2.jira' => 'user.3@email.com',
@@ -121,7 +122,7 @@ final class EmailNotifierCommandTest extends TestCase
             [
                 new Channel(
                     new Mailer($transport),
-                    MessageGenerator::beingNow(new DateTimeImmutable())
+                    $this->messageGenerator()
                 ),
             ]
         );
@@ -151,7 +152,7 @@ final class EmailNotifierCommandTest extends TestCase
             [
                 new Email\Channel(
                     new Mailer($transport),
-                    Email\MessageGenerator::beingNow(new DateTimeImmutable())
+                    $this->messageGenerator()
                 ),
             ]
         );
@@ -176,9 +177,14 @@ final class EmailNotifierCommandTest extends TestCase
             [
                 new Email\Channel(
                     new Mailer($this->createMock(TransportInterface::class)),
-                    Email\MessageGenerator::beingNow(new DateTimeImmutable())
+                    $this->messageGenerator()
                 ),
             ]
         );
+    }
+
+    private function messageGenerator(): Email\MessageGenerator
+    {
+        return new Email\MessageGenerator(new DateTimeImmutable(), $this->createMock(Environment::class));
     }
 }

--- a/tests/ScrumMasterTest/Unit/Channel/Slack/MessageGeneratorTest.php
+++ b/tests/ScrumMasterTest/Unit/Channel/Slack/MessageGeneratorTest.php
@@ -40,7 +40,7 @@ TXT;
         );
 
         $slackMessage = MessageGenerator::beingNow($statusDateChange);
-        $this->assertEquals($expectedMessage, $slackMessage->forJiraTickets([$ticket,$ticket], 'company-name'));
+        $this->assertEquals($expectedMessage, $slackMessage->forJiraTickets([$ticket, $ticket], 'company-name'));
     }
 
     /** @test */


### PR DESCRIPTION
# Description

Instead of having the "email body" in a PHP class I would prefer if the "view" part would it be in a separate twig file. 

I encapsulated the template view where is rendered the email content in a file called "email-template.twig"

Issue: #38 