### PR TITLE
Replace empty array key by none when nobody is assigned to a JiraTicket

### DIFF
--- a/src/ScrumMaster/Channel/ChannelResult.php
+++ b/src/ScrumMaster/Channel/ChannelResult.php
@@ -53,7 +53,7 @@ final class ChannelResult
             }
         }
 
-        return $this->replaceEmptyKeyArray($tickets);
+        return $this->replaceKey($tickets);
     }
 
     public function total(): int
@@ -96,10 +96,10 @@ final class ChannelResult
         return $people;
     }
 
-    private function replaceEmptyKeyArray(array $tickets, string $replacement = 'None'): array
+    private function replaceKey(array $tickets, string $from = '', string $to = 'None'): array
     {
-        $tickets[$replacement] = $tickets[''];
-        unset($tickets['']);
+        $tickets[$to] = $tickets[$from];
+        unset($tickets[$from]);
 
         return $tickets;
     }

--- a/src/ScrumMaster/Channel/ChannelResult.php
+++ b/src/ScrumMaster/Channel/ChannelResult.php
@@ -53,7 +53,7 @@ final class ChannelResult
             }
         }
 
-        return $tickets;
+        return $this->replaceEmptyKeyArray($tickets);
     }
 
     public function total(): int
@@ -94,5 +94,13 @@ final class ChannelResult
         sort($people);
 
         return $people;
+    }
+
+    private function replaceEmptyKeyArray(array $tickets, string $replacement = 'None'): array
+    {
+        $tickets[$replacement] = $tickets[''];
+        unset($tickets['']);
+
+        return $tickets;
     }
 }

--- a/src/ScrumMaster/Channel/ChannelResult.php
+++ b/src/ScrumMaster/Channel/ChannelResult.php
@@ -53,7 +53,7 @@ final class ChannelResult
             }
         }
 
-        return $this->replaceKey($tickets);
+        return $this->replaceKey($tickets, $from = '', $to = 'None');
     }
 
     public function total(): int
@@ -96,7 +96,7 @@ final class ChannelResult
         return $people;
     }
 
-    private function replaceKey(array $tickets, string $from = '', string $to = 'None'): array
+    private function replaceKey(array $tickets, string $from, string $to): array
     {
         $tickets[$to] = $tickets[$from];
         unset($tickets[$from]);

--- a/tests/ScrumMasterTest/Unit/Channel/ChannelResultTest.php
+++ b/tests/ScrumMasterTest/Unit/Channel/ChannelResultTest.php
@@ -52,7 +52,7 @@ final class ChannelResultTest extends TestCase
     public function ticketsAssignedToPeople(): void
     {
         self::assertEquals([
-            null => ['K-1'],
+            'None' => ['K-1'],
             'j.user.1' => ['K-2', 'K-3'],
             'j.user.2' => ['K-4'],
         ], $this->result->ticketsAssignedToPeople());


### PR DESCRIPTION
# Description

I am not sure which name is better for the `replaceEmptyKeyArray()` function.
If `replaceEmptyKeyArray`, `replaceNullByNoneIfNobodyAssignedToTicket` or any other construction.
Also, does it worth to put a default value or just put directly `None` as array key?

What do you think @Chemaclass?

Issue: #44 

# Changes

- [x] Add `\Chemaclass\ScrumMaster\Channel\ChannelResult::replaceKey()`.
- [x] Update `\Chemaclass\ScrumMasterTests\Unit\Channel\ChannelResultTest::ticketsAssignedToPeople()`.

# Checklist

- [x] Tests are passing
- [x] Mutants are defeated
- [x] Code coverage is not decreased
