### PR TITLE
Make Story Points key customizable from outside

### DIFF
--- a/src/ScrumMaster/Jira/Tickets.php
+++ b/src/ScrumMaster/Jira/Tickets.php
@@ -9,10 +9,11 @@ use Chemaclass\ScrumMaster\Jira\ReadModel\JiraTicket;
 use Chemaclass\ScrumMaster\Jira\ReadModel\TicketStatus;
 use DateTimeImmutable;
 use Symfony\Contracts\HttpClient\ResponseInterface;
+use Webmozart\Assert\Assert;
 
 final class Tickets
 {
-    public const FIELD_STORY_POINTS = 'customfield_10005';
+    private static string $fieldStoryPoints;
 
     /** @return JiraTicket[] */
     public static function fromJiraResponse(ResponseInterface $response): array
@@ -41,7 +42,7 @@ final class Tickets
             $item['key'],
             static::newTicketStatus($fields),
             static::newAssignee($fields['assignee'] ?? []),
-            $storyPoints = (int) $fields[self::FIELD_STORY_POINTS]
+            $storyPoints = (int) $fields[self::$fieldStoryPoints]
         );
     }
 
@@ -65,5 +66,16 @@ final class Tickets
             $assignee['displayName'] ?? '',
             $assignee['emailAddress'] ?? ''
         );
+    }
+
+    public function __construct(string $fieldStoryPoints)
+    {
+        Assert::notEmpty($fieldStoryPoints);
+        self::$fieldStoryPoints = $fieldStoryPoints;
+    }
+
+    public function getFieldStoryPoints(): string
+    {
+        return self::$fieldStoryPoints;
     }
 }

--- a/src/ScrumMaster/Jira/Tickets.php
+++ b/src/ScrumMaster/Jira/Tickets.php
@@ -33,6 +33,17 @@ final class Tickets
         return $jiraTickets;
     }
 
+    public function __construct(string $fieldStoryPoints)
+    {
+        Assert::notEmpty($fieldStoryPoints);
+        self::$fieldStoryPoints = $fieldStoryPoints;
+    }
+
+    public function getFieldStoryPoints(): string
+    {
+        return self::$fieldStoryPoints;
+    }
+
     private static function newJiraTicket(array $item): JiraTicket
     {
         $fields = $item['fields'];
@@ -66,16 +77,5 @@ final class Tickets
             $assignee['displayName'] ?? '',
             $assignee['emailAddress'] ?? ''
         );
-    }
-
-    public function __construct(string $fieldStoryPoints)
-    {
-        Assert::notEmpty($fieldStoryPoints);
-        self::$fieldStoryPoints = $fieldStoryPoints;
-    }
-
-    public function getFieldStoryPoints(): string
-    {
-        return self::$fieldStoryPoints;
     }
 }

--- a/tests/ScrumMasterTest/Unit/Concerns/JiraApiResource.php
+++ b/tests/ScrumMasterTest/Unit/Concerns/JiraApiResource.php
@@ -35,7 +35,7 @@ trait JiraApiResource
         return [
             'key' => $key,
             'fields' => [
-                Tickets::FIELD_STORY_POINTS => '5.0',
+                (new Tickets('customfield_10005'))->getFieldStoryPoints() => '5.0',
                 'status' => [
                     'name' => $statusName,
                 ],

--- a/tests/ScrumMasterTest/Unit/Jira/TicketsTest.php
+++ b/tests/ScrumMasterTest/Unit/Jira/TicketsTest.php
@@ -9,11 +9,20 @@ use Chemaclass\ScrumMaster\Jira\ReadModel\JiraTicket;
 use Chemaclass\ScrumMaster\Jira\ReadModel\TicketStatus;
 use Chemaclass\ScrumMaster\Jira\Tickets;
 use DateTimeImmutable;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class TicketsTest extends TestCase
 {
+    /** @test */
+    public function constructorNotEmpty(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new Tickets('');
+    }
+
     /** @test */
     public function fromJira(): void
     {


### PR DESCRIPTION
# Description

Replace `Tickets::FIELD_STORY_POINTS` constant by a class property.

Issue: #51 

# Questions

@Chemaclass Should I create `Tickets->getFieldStoryPoints()` method or is it better the static `$fieldStoryPoints` property public?
