### PR TITLE
Variadic function syntax

### DIFF
--- a/examples/using-all-channels/console
+++ b/examples/using-all-channels/console
@@ -58,7 +58,7 @@ $channels = [
     new Cli\Channel(),
 ];
 
-$jiraConnector = new JiraConnector($jiraHttpClient, $channels);
+$jiraConnector = new JiraConnector($jiraHttpClient, ...$channels);
 
 $result = $jiraConnector->handle(JiraConnectorInput::new(
     getenv(JiraConnectorInput::COMPANY_NAME),

--- a/examples/using-cli-channel/console
+++ b/examples/using-cli-channel/console
@@ -31,7 +31,7 @@ $jiraHttpClient = new JiraHttpClient(
     new JiraTicketsFactory(['customfield_10005' => 'StoryPoints'])
 );
 
-$jiraConnector = new JiraConnector($jiraHttpClient, [new Cli\Channel()]);
+$jiraConnector = new JiraConnector($jiraHttpClient, new Cli\Channel());
 
 $result = $jiraConnector->handle(JiraConnectorInput::new(
     getenv(JiraConnectorInput::COMPANY_NAME),

--- a/examples/using-email-channel/console
+++ b/examples/using-email-channel/console
@@ -48,7 +48,7 @@ $channels = [
     ),
 ];
 
-$jiraConnector = new JiraConnector($jiraHttpClient, $channels);
+$jiraConnector = new JiraConnector($jiraHttpClient, ...$channels);
 
 $result = $jiraConnector->handle(JiraConnectorInput::new(
     $_ENV[JiraConnectorInput::COMPANY_NAME],

--- a/examples/using-email-channel/console
+++ b/examples/using-email-channel/console
@@ -37,18 +37,16 @@ $jiraHttpClient = new JiraHttpClient(
     new JiraTicketsFactory(['customfield_10005' => 'StoryPoints'])
 );
 
-$channels = [
-    new Email\Channel(
-        new Mailer(new GmailSmtpTransport(getenv('MAILER_USERNAME'), getenv('MAILER_PASSWORD'))),
-        new MessageGenerator(new DateTimeImmutable(), $twig, 'email-template.twig'),
-        new Email\AddressGenerator((new ByPassEmail())
-            ->setSendEmailsToAssignee(false) // <- OverriddenEmails wont have effect as long as this is false
-            ->setOverriddenEmails(json_decode(getenv('OVERRIDDEN_EMAILS'), true))
-            ->setSendCopyTo(getenv('MAILER_USERNAME')))
-    ),
-];
+$channel = new Email\Channel(
+    new Mailer(new GmailSmtpTransport(getenv('MAILER_USERNAME'), getenv('MAILER_PASSWORD'))),
+    new MessageGenerator(new DateTimeImmutable(), $twig, 'email-template.twig'),
+    new Email\AddressGenerator((new ByPassEmail())
+        ->setSendEmailsToAssignee(false) // <- OverriddenEmails wont have effect as long as this is false
+        ->setOverriddenEmails(json_decode(getenv('OVERRIDDEN_EMAILS'), true))
+        ->setSendCopyTo(getenv('MAILER_USERNAME')))
+);
 
-$jiraConnector = new JiraConnector($jiraHttpClient, ...$channels);
+$jiraConnector = new JiraConnector($jiraHttpClient, $channel);
 
 $result = $jiraConnector->handle(JiraConnectorInput::new(
     $_ENV[JiraConnectorInput::COMPANY_NAME],

--- a/examples/using-slack-channel/console
+++ b/examples/using-slack-channel/console
@@ -34,17 +34,15 @@ $jiraHttpClient = new JiraHttpClient(
     new JiraTicketsFactory(['customfield_10005' => 'StoryPoints'])
 );
 
-$channels = [
-    new Slack\Channel(
-        new Slack\HttpClient(HttpClient::create([
-            'auth_bearer' => getenv('SLACK_BOT_USER_OAUTH_ACCESS_TOKEN'),
-        ])),
-        Slack\JiraMapping::jiraNameWithSlackId(json_decode(getenv('SLACK_MAPPING_IDS'), true)),
-        new MessageGenerator(new DateTimeImmutable(), $twig, 'slack-template.twig')
-    ),
-];
+$channel = new Slack\Channel(
+    new Slack\HttpClient(HttpClient::create([
+        'auth_bearer' => getenv('SLACK_BOT_USER_OAUTH_ACCESS_TOKEN'),
+    ])),
+    Slack\JiraMapping::jiraNameWithSlackId(json_decode(getenv('SLACK_MAPPING_IDS'), true)),
+    new MessageGenerator(new DateTimeImmutable(), $twig, 'slack-template.twig')
+);
 
-$jiraConnector = new JiraConnector($jiraHttpClient, ...$channels);
+$jiraConnector = new JiraConnector($jiraHttpClient, $channel);
 
 $result = $jiraConnector->handle(JiraConnectorInput::new(
     $_ENV[JiraConnectorInput::COMPANY_NAME],

--- a/examples/using-slack-channel/console
+++ b/examples/using-slack-channel/console
@@ -44,7 +44,7 @@ $channels = [
     ),
 ];
 
-$jiraConnector = new JiraConnector($jiraHttpClient, $channels);
+$jiraConnector = new JiraConnector($jiraHttpClient, ...$channels);
 
 $result = $jiraConnector->handle(JiraConnectorInput::new(
     $_ENV[JiraConnectorInput::COMPANY_NAME],

--- a/src/JiraStatusNotifier/Jira/Board.php
+++ b/src/JiraStatusNotifier/Jira/Board.php
@@ -4,28 +4,24 @@ declare(strict_types=1);
 
 namespace Chemaclass\JiraStatusNotifier\Jira;
 
+/** @psalm-immutable */
 final class Board implements BoardInterface
 {
-    public const FALLBACK_VALUE_DEFAULT = 1;
+    /** @var array<string, int> */
+    private array $maxDaysInStatus;
 
-    /** @var array<string,int> */
-    private $maxDaysInStatus;
-
-    private int $fallbackValue;
-
-    public function __construct(array $maxDaysInStatus, int $fallbackValue = self::FALLBACK_VALUE_DEFAULT)
+    public function __construct(array $maxDaysInStatus)
     {
         $this->maxDaysInStatus = $maxDaysInStatus;
-        $this->fallbackValue = $fallbackValue;
-    }
-
-    public function getDaysForStatus(string $status): int
-    {
-        return $this->maxDaysInStatus()[$status] ?? $this->fallbackValue;
     }
 
     public function maxDaysInStatus(): array
     {
         return $this->maxDaysInStatus;
+    }
+
+    public function getDaysForStatus(string $status): int
+    {
+        return $this->maxDaysInStatus[$status] ?? 0;
     }
 }

--- a/src/JiraStatusNotifier/JiraConnector.php
+++ b/src/JiraStatusNotifier/JiraConnector.php
@@ -13,18 +13,16 @@ use Chemaclass\JiraStatusNotifier\Jira\JiraHttpClient;
 use Chemaclass\JiraStatusNotifier\Jira\JqlUrlBuilder;
 use Chemaclass\JiraStatusNotifier\Jira\JqlUrlFactory;
 use Chemaclass\JiraStatusNotifier\Jira\ReadModel\Company;
-use Webmozart\Assert\Assert;
 
 final class JiraConnector
 {
     private JiraHttpClient $jiraHttpClient;
 
-    /** @var ChannelInterface[] */
-    private $channels;
+    /** @psalm-param list<ChannelInterface> */
+    private array $channels;
 
-    public function __construct(JiraHttpClient $jiraHttpClient, array $channels)
+    public function __construct(JiraHttpClient $jiraHttpClient, ChannelInterface...$channels)
     {
-        Assert::allIsInstanceOf($channels, ChannelInterface::class);
         $this->jiraHttpClient = $jiraHttpClient;
         $this->channels = $channels;
     }

--- a/src/JiraStatusNotifier/JiraConnector.php
+++ b/src/JiraStatusNotifier/JiraConnector.php
@@ -40,17 +40,14 @@ final class JiraConnector
         $company = Company::withNameAndProject($input->companyName(), $input->jiraProjectName());
         $result = [];
 
-        $ticketsByAssignee = new TicketsByAssignee(
+        $ticketsByAssignee = (new TicketsByAssignee(
             $this->jiraHttpClient,
             new JqlUrlFactory($jiraBoard, JqlUrlBuilder::inOpenSprints($company)),
             $input->jiraUsersToIgnore()
-        );
+        ))->fetchFromBoard($jiraBoard);
 
         foreach ($this->channels as $channel) {
-            $result[get_class($channel)] = $channel->send(
-                $ticketsByAssignee->fetchFromBoard($jiraBoard),
-                $company
-            );
+            $result[get_class($channel)] = $channel->send($ticketsByAssignee, $company);
         }
 
         return $result;

--- a/tests/JiraStatusNotifierTest/Functional/CliNotifierTest.php
+++ b/tests/JiraStatusNotifierTest/Functional/CliNotifierTest.php
@@ -70,7 +70,7 @@ final class CliNotifierTest extends TestCase
     {
         return new JiraConnector(
             new JiraHttpClient($this->mockJiraClient($jiraIssues), new JiraTicketsFactory()),
-            [new Cli\Channel()]
+            new Cli\Channel()
         );
     }
 }

--- a/tests/JiraStatusNotifierTest/Functional/EmailNotifierTest.php
+++ b/tests/JiraStatusNotifierTest/Functional/EmailNotifierTest.php
@@ -90,16 +90,14 @@ final class EmailNotifierTest extends TestCase
 
         $jiraConnector = new JiraConnector(
             new JiraHttpClient($this->mockJiraClient($jiraIssues), new JiraTicketsFactory()),
-            [
-                new Channel(
-                    new Mailer($transport),
-                    $this->messageGenerator(),
-                    new AddressGenerator((new ByPassEmail())->setOverriddenEmails([
-                        'user.1.jira' => 'user.3@email.com',
-                        'user.2.jira' => 'user.3@email.com',
-                    ]))
-                ),
-            ]
+            new Channel(
+                new Mailer($transport),
+                $this->messageGenerator(),
+                new AddressGenerator((new ByPassEmail())->setOverriddenEmails([
+                    'user.1.jira' => 'user.3@email.com',
+                    'user.2.jira' => 'user.3@email.com',
+                ]))
+            )
         );
 
         $jiraConnector->handle($this->jiraConnectorInput());
@@ -123,9 +121,7 @@ final class EmailNotifierTest extends TestCase
                 ]),
                 new JiraTicketsFactory()
             ),
-            [
-                new Channel(new Mailer($transport), $this->messageGenerator()),
-            ]
+            new Channel(new Mailer($transport), $this->messageGenerator()),
         );
 
         $results = $jiraConnector->handle($this->jiraConnectorInput());
@@ -153,9 +149,7 @@ final class EmailNotifierTest extends TestCase
                 ]),
                 new JiraTicketsFactory()
             ),
-            [
-                new Email\Channel(new Mailer($transport), $this->messageGenerator()),
-            ]
+            new Email\Channel(new Mailer($transport), $this->messageGenerator())
         );
 
         $jiraConnector->handle($this->jiraConnectorInput());
@@ -178,12 +172,10 @@ final class EmailNotifierTest extends TestCase
                 $this->mockJiraClient($jiraIssues),
                 new JiraTicketsFactory()
             ),
-            [
-                new Email\Channel(
-                    new Mailer($this->createMock(TransportInterface::class)),
-                    $this->messageGenerator()
-                ),
-            ]
+            new Email\Channel(
+                new Mailer($this->createMock(TransportInterface::class)),
+                $this->messageGenerator()
+            )
         );
     }
 

--- a/tests/JiraStatusNotifierTest/Functional/SlackNotifierTest.php
+++ b/tests/JiraStatusNotifierTest/Functional/SlackNotifierTest.php
@@ -77,17 +77,15 @@ final class SlackNotifierTest extends TestCase
                 $this->mockJiraClient($jiraIssues),
                 new JiraTicketsFactory()
             ),
-            [
-                new Slack\Channel(
-                    new Slack\HttpClient($this->createMock(HttpClientInterface::class)),
-                    Slack\JiraMapping::jiraNameWithSlackId(['jira.id' => 'slack.id']),
-                    new MessageGenerator(
-                        new DateTimeImmutable(),
-                        $this->createMock(Environment::class),
-                        'template-name.twig'
-                    )
-                ),
-            ]
+            new Slack\Channel(
+                new Slack\HttpClient($this->createMock(HttpClientInterface::class)),
+                Slack\JiraMapping::jiraNameWithSlackId(['jira.id' => 'slack.id']),
+                new MessageGenerator(
+                    new DateTimeImmutable(),
+                    $this->createMock(Environment::class),
+                    'template-name.twig'
+                )
+            )
         );
     }
 }

--- a/tests/JiraStatusNotifierTest/Unit/Jira/BoardTest.php
+++ b/tests/JiraStatusNotifierTest/Unit/Jira/BoardTest.php
@@ -13,15 +13,13 @@ final class BoardTest extends TestCase
     public function daysForStatus(): void
     {
         $board = new Board(['status1' => 1, 'status2' => 2]);
-        $this->assertEquals(2, $board->getDaysForStatus('status2'));
-        $this->assertEquals(Board::FALLBACK_VALUE_DEFAULT, $board->getDaysForStatus('statusNotFound'));
+        self::assertEquals(2, $board->getDaysForStatus('status2'));
     }
 
     /** @test */
     public function daysForStatusWhenStatusNotFound(): void
     {
-        $fallbackValue = 9999;
-        $board = new Board(['status1' => 1], $fallbackValue);
-        $this->assertEquals($fallbackValue, $board->getDaysForStatus('statusNotFound'));
+        $board = new Board(['status1' => 1]);
+        self::assertEquals(0, $board->getDaysForStatus('statusNotFound'));
     }
 }

--- a/tests/JiraStatusNotifierTest/Unit/Jira/JqlUrlFactoryTest.php
+++ b/tests/JiraStatusNotifierTest/Unit/Jira/JqlUrlFactoryTest.php
@@ -25,18 +25,4 @@ final class JqlUrlFactoryTest extends TestCase
         $expected .= ' AND NOT status changed after -2d';
         $this->assertEquals($expected, $factory->buildUrl('statusName'));
     }
-
-    /** @test */
-    public function buildForAnUnknownStatus(): void
-    {
-        $factory = new JqlUrlFactory(
-            new Board(['status' => 2], $fallbackValue = 99),
-            JqlUrlBuilder::inOpenSprints(Company::withName('company'))
-        );
-
-        $expected = 'https://company.atlassian.net/rest/api/3/search?jql=sprint in openSprints()';
-        $expected .= " AND status IN ('unknown-status')";
-        $expected .= ' AND NOT status changed after -99d';
-        $this->assertEquals($expected, $factory->buildUrl('unknown-status'));
-    }
 }

--- a/tests/JiraStatusNotifierTest/Unit/JiraConnectorTest.php
+++ b/tests/JiraStatusNotifierTest/Unit/JiraConnectorTest.php
@@ -57,7 +57,7 @@ final class JiraConnectorTest extends TestCase
 
         return new JiraConnector(
             new JiraHttpClient($this->mockJiraClient([]), new JiraTicketsFactory()),
-            [$channel]
+            $channel
         );
     }
 }


### PR DESCRIPTION
# Description

In order to encourage strict typing, we would use variadic function syntax instead of plain array whenever is possible 🪂