### PR TITLE
Refactor ticket by assignee

### DIFF
--- a/src/JiraStatusNotifier/Channel/ChannelInterface.php
+++ b/src/JiraStatusNotifier/Channel/ChannelInterface.php
@@ -8,5 +8,5 @@ use Chemaclass\JiraStatusNotifier\Jira\ReadModel\Company;
 
 interface ChannelInterface
 {
-    public function send(array $ticketsByAssignee, Company $company): ChannelResult;
+    public function send(Company $company, TicketsByAssignee $ticketsByAssignee): ChannelResult;
 }

--- a/src/JiraStatusNotifier/Channel/Cli/Channel.php
+++ b/src/JiraStatusNotifier/Channel/Cli/Channel.php
@@ -7,15 +7,16 @@ namespace Chemaclass\JiraStatusNotifier\Channel\Cli;
 use Chemaclass\JiraStatusNotifier\Channel\ChannelInterface;
 use Chemaclass\JiraStatusNotifier\Channel\ChannelResult;
 use Chemaclass\JiraStatusNotifier\Channel\ReadModel\ChannelIssue;
+use Chemaclass\JiraStatusNotifier\Channel\TicketsByAssignee;
 use Chemaclass\JiraStatusNotifier\Jira\ReadModel\Company;
 
 final class Channel implements ChannelInterface
 {
-    public function send(array $ticketsByAssignee, Company $company): ChannelResult
+    public function send(Company $company, TicketsByAssignee $ticketsByAssignee): ChannelResult
     {
         $result = new ChannelResult();
 
-        foreach ($ticketsByAssignee as $assigneeKey => $tickets) {
+        foreach ($ticketsByAssignee->list() as $assigneeKey => $tickets) {
             foreach ($tickets as $ticket) {
                 $issue = ChannelIssue::withAssignee($ticket->assignee()->displayName());
                 $result->addChannelIssue($ticket->key(), $issue);

--- a/src/JiraStatusNotifier/Channel/Email/Channel.php
+++ b/src/JiraStatusNotifier/Channel/Email/Channel.php
@@ -65,7 +65,7 @@ final class Channel implements ChannelInterface
 
             return Request::HTTP_OK;
         } catch (TransportExceptionInterface $e) {
-            return (int)$e->getCode();
+            return (int) $e->getCode();
         }
     }
 }

--- a/src/JiraStatusNotifier/Channel/MessageGenerator.php
+++ b/src/JiraStatusNotifier/Channel/MessageGenerator.php
@@ -25,8 +25,6 @@ final class MessageGenerator
 
     public function forJiraTickets(string $companyName, JiraTicket...$tickets): string
     {
-        uksort($tickets, 'strnatcasecmp');
-
         return $this->twig->render(
             $this->templateName,
             [

--- a/src/JiraStatusNotifier/Channel/MessageGenerator.php
+++ b/src/JiraStatusNotifier/Channel/MessageGenerator.php
@@ -7,7 +7,6 @@ namespace Chemaclass\JiraStatusNotifier\Channel;
 use Chemaclass\JiraStatusNotifier\Jira\ReadModel\JiraTicket;
 use DateTimeImmutable;
 use Twig;
-use Webmozart\Assert\Assert;
 
 final class MessageGenerator
 {
@@ -24,9 +23,8 @@ final class MessageGenerator
         $this->templateName = $templateName;
     }
 
-    public function forJiraTickets(array $tickets, string $companyName): string
+    public function forJiraTickets(string $companyName, JiraTicket...$tickets): string
     {
-        Assert::allIsInstanceOf($tickets, JiraTicket::class);
         uksort($tickets, 'strnatcasecmp');
 
         return $this->twig->render(

--- a/src/JiraStatusNotifier/Channel/TicketsByAssignee.php
+++ b/src/JiraStatusNotifier/Channel/TicketsByAssignee.php
@@ -8,7 +8,7 @@ use Chemaclass\JiraStatusNotifier\Jira\ReadModel\JiraTicket;
 
 final class TicketsByAssignee
 {
-    /** @psalm-prop array<string, list<JiraTicket>> */
+    /** @psalm-var array<string, list<JiraTicket>> */
     private array $list = [];
 
     public function add(JiraTicket $ticket): self

--- a/src/JiraStatusNotifier/Channel/TicketsByAssignee.php
+++ b/src/JiraStatusNotifier/Channel/TicketsByAssignee.php
@@ -24,6 +24,7 @@ final class TicketsByAssignee
         return $this;
     }
 
+    /** @psalm-return array<string, list<JiraTicket>> */
     public function list(): array
     {
         return $this->list;

--- a/src/JiraStatusNotifier/Channel/TicketsByAssignee.php
+++ b/src/JiraStatusNotifier/Channel/TicketsByAssignee.php
@@ -4,73 +4,28 @@ declare(strict_types=1);
 
 namespace Chemaclass\JiraStatusNotifier\Channel;
 
-use function array_merge;
-use Chemaclass\JiraStatusNotifier\Jira\Board;
-use Chemaclass\JiraStatusNotifier\Jira\JiraHttpClient;
-use Chemaclass\JiraStatusNotifier\Jira\JqlUrlFactory;
 use Chemaclass\JiraStatusNotifier\Jira\ReadModel\JiraTicket;
-use function in_array;
 
 final class TicketsByAssignee
 {
-    private JiraHttpClient $jiraClient;
+    /** @psalm-prop array<string, list<JiraTicket>> */
+    private array $list = [];
 
-    private JqlUrlFactory $jqlUrlFactory;
-
-    /** @var array */
-    private $jiraUsersToIgnore;
-
-    public function __construct(
-        JiraHttpClient $jiraClient,
-        JqlUrlFactory $jqlUrlFactory,
-        array $jiraUsersToIgnore
-    ) {
-        $this->jiraClient = $jiraClient;
-        $this->jqlUrlFactory = $jqlUrlFactory;
-        $this->jiraUsersToIgnore = $jiraUsersToIgnore;
-    }
-
-    /** @psalm-return array<string, array<array-key, JiraTicket>> */
-    public function fetchFromBoard(Board $board): array
+    public function add(JiraTicket $ticket): self
     {
-        $ticketsByAssignee = [];
+        $assignee = $ticket->assignee();
 
-        foreach ($board->maxDaysInStatus() as $statusName => $maxDays) {
-            $grouped = $this->ticketsByAssigneeInStatus($statusName);
-
-            foreach ($grouped as $assigneeKey => $tickets) {
-                if (!isset($ticketsByAssignee[$assigneeKey])) {
-                    $ticketsByAssignee[$assigneeKey] = $tickets;
-                } else {
-                    $ticketsByAssignee[$assigneeKey] = array_merge($ticketsByAssignee[$assigneeKey], $tickets);
-                }
-            }
+        if (!isset($this->list[$assignee->key()])) {
+            $this->list[$assignee->key()] = [];
         }
 
-        return $ticketsByAssignee;
+        $this->list[$assignee->key()][] = $ticket;
+
+        return $this;
     }
 
-    /** @psalm-return array<string, array<string, JiraTicket>> */
-    private function ticketsByAssigneeInStatus(string $statusName): array
+    public function list(): array
     {
-        $tickets = $this->jiraClient->getTickets($this->jqlUrlFactory, $statusName);
-        $ticketsByAssignee = [];
-
-        /** @var JiraTicket $ticket */
-        foreach ($tickets as $ticket) {
-            $assignee = $ticket->assignee();
-
-            if (in_array($assignee->key(), $this->jiraUsersToIgnore)) {
-                continue;
-            }
-
-            if (!isset($ticketsByAssignee[$assignee->key()])) {
-                $ticketsByAssignee[$assignee->key()] = [];
-            }
-
-            $ticketsByAssignee[$assignee->key()][$ticket->key()] = $ticket;
-        }
-
-        return $ticketsByAssignee;
+        return $this->list;
     }
 }

--- a/src/JiraStatusNotifier/Channel/TicketsByAssigneeClient.php
+++ b/src/JiraStatusNotifier/Channel/TicketsByAssigneeClient.php
@@ -7,7 +7,6 @@ namespace Chemaclass\JiraStatusNotifier\Channel;
 use Chemaclass\JiraStatusNotifier\Jira\Board;
 use Chemaclass\JiraStatusNotifier\Jira\JiraHttpClient;
 use Chemaclass\JiraStatusNotifier\Jira\JqlUrlFactory;
-use Chemaclass\JiraStatusNotifier\Jira\ReadModel\JiraTicket;
 use function in_array;
 
 final class TicketsByAssigneeClient
@@ -28,7 +27,6 @@ final class TicketsByAssigneeClient
         $this->jiraUsersToIgnore = $jiraUsersToIgnore;
     }
 
-    /** @psalm-return array<string, array<array-key, JiraTicket>> */
     public function fetchFromBoard(Board $board): TicketsByAssignee
     {
         $ticketsByAssignee = new TicketsByAssignee();

--- a/src/JiraStatusNotifier/Channel/TicketsByAssigneeClient.php
+++ b/src/JiraStatusNotifier/Channel/TicketsByAssigneeClient.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Chemaclass\JiraStatusNotifier\Channel;
+
+use Chemaclass\JiraStatusNotifier\Jira\Board;
+use Chemaclass\JiraStatusNotifier\Jira\JiraHttpClient;
+use Chemaclass\JiraStatusNotifier\Jira\JqlUrlFactory;
+use Chemaclass\JiraStatusNotifier\Jira\ReadModel\JiraTicket;
+use function in_array;
+
+final class TicketsByAssigneeClient
+{
+    private JiraHttpClient $jiraClient;
+
+    private JqlUrlFactory $jqlUrlFactory;
+
+    private array $jiraUsersToIgnore;
+
+    public function __construct(
+        JiraHttpClient $jiraClient,
+        JqlUrlFactory $jqlUrlFactory,
+        array $jiraUsersToIgnore
+    ) {
+        $this->jiraClient = $jiraClient;
+        $this->jqlUrlFactory = $jqlUrlFactory;
+        $this->jiraUsersToIgnore = $jiraUsersToIgnore;
+    }
+
+    /** @psalm-return array<string, array<array-key, JiraTicket>> */
+    public function fetchFromBoard(Board $board): TicketsByAssignee
+    {
+        $ticketsByAssignee = new TicketsByAssignee();
+
+        foreach ($board->maxDaysInStatus() as $statusName => $maxDays) {
+            $tickets = $this->jiraClient->getTickets($this->jqlUrlFactory, $statusName);
+
+            foreach ($tickets as $ticket) {
+                if (in_array($ticket->assignee()->key(), $this->jiraUsersToIgnore)) {
+                    continue;
+                }
+
+                $ticketsByAssignee->add($ticket);
+            }
+        }
+
+        return $ticketsByAssignee;
+    }
+}

--- a/src/JiraStatusNotifier/Jira/ReadModel/JiraTicket.php
+++ b/src/JiraStatusNotifier/Jira/ReadModel/JiraTicket.php
@@ -14,8 +14,7 @@ final class JiraTicket
 
     private Assignee $assignee;
 
-    /** @var array */
-    private $customFields;
+    private array $customFields;
 
     public function __construct(
         string $title,

--- a/src/JiraStatusNotifier/JiraConnector.php
+++ b/src/JiraStatusNotifier/JiraConnector.php
@@ -6,7 +6,7 @@ namespace Chemaclass\JiraStatusNotifier;
 
 use Chemaclass\JiraStatusNotifier\Channel\ChannelInterface;
 use Chemaclass\JiraStatusNotifier\Channel\ChannelResult;
-use Chemaclass\JiraStatusNotifier\Channel\TicketsByAssignee;
+use Chemaclass\JiraStatusNotifier\Channel\TicketsByAssigneeClient;
 use Chemaclass\JiraStatusNotifier\IO\JiraConnectorInput;
 use Chemaclass\JiraStatusNotifier\Jira\Board;
 use Chemaclass\JiraStatusNotifier\Jira\JiraHttpClient;
@@ -38,14 +38,14 @@ final class JiraConnector
         $company = Company::withNameAndProject($input->companyName(), $input->jiraProjectName());
         $result = [];
 
-        $ticketsByAssignee = (new TicketsByAssignee(
+        $ticketsByAssignee = (new TicketsByAssigneeClient(
             $this->jiraHttpClient,
             new JqlUrlFactory($jiraBoard, JqlUrlBuilder::inOpenSprints($company)),
             $input->jiraUsersToIgnore()
         ))->fetchFromBoard($jiraBoard);
 
         foreach ($this->channels as $channel) {
-            $result[get_class($channel)] = $channel->send($ticketsByAssignee, $company);
+            $result[get_class($channel)] = $channel->send($company, $ticketsByAssignee);
         }
 
         return $result;

--- a/tests/JiraStatusNotifierTest/Unit/Channel/MessageGeneratorTest.php
+++ b/tests/JiraStatusNotifierTest/Unit/Channel/MessageGeneratorTest.php
@@ -8,28 +8,12 @@ use Chemaclass\JiraStatusNotifier\Channel\MessageGenerator;
 use Chemaclass\JiraStatusNotifier\Jira\JiraTicketsFactory;
 use Chemaclass\JiraStatusNotifierTests\Unit\Concerns\JiraApiResource;
 use DateTimeImmutable;
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Twig;
 
 final class MessageGeneratorTest extends TestCase
 {
     use JiraApiResource;
-
-    /** @test */
-    public function forJiraTicketsWrongType(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        $generator = new MessageGenerator(
-            new DateTimeImmutable(),
-            $this->createMock(Twig\Environment::class),
-            'template-name.twig'
-        );
-
-        $invalidTypes = [new \stdClass()];
-        $generator->forJiraTickets($invalidTypes, 'Any company name');
-    }
 
     /** @test */
     public function forJiraTickets(): void
@@ -52,6 +36,6 @@ final class MessageGeneratorTest extends TestCase
         );
 
         $generator = new MessageGenerator($now, $twigMock, $templateName);
-        $generator->forJiraTickets($tickets, $companyName);
+        $generator->forJiraTickets($companyName, ...$tickets);
     }
 }

--- a/tests/JiraStatusNotifierTest/Unit/Channel/TicketsByAssigneeTest.php
+++ b/tests/JiraStatusNotifierTest/Unit/Channel/TicketsByAssigneeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Chemaclass\JiraStatusNotifierTests\Unit\Channel;
+
+use Chemaclass\JiraStatusNotifier\Channel\TicketsByAssignee;
+use Chemaclass\JiraStatusNotifier\Jira\ReadModel\Assignee;
+use Chemaclass\JiraStatusNotifier\Jira\ReadModel\JiraTicket;
+use Chemaclass\JiraStatusNotifier\Jira\ReadModel\TicketStatus;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+final class TicketsByAssigneeTest extends TestCase
+{
+    /** @test */
+    public function add(): void
+    {
+        $ticket1 = $this->newJiraTicket('assigneeKey1', 'KEY-1');
+        $ticket2 = $this->newJiraTicket('assigneeKey1', 'KEY-2');
+        $ticket3 = $this->newJiraTicket('assigneeKey2', 'KEY-3');
+
+        $ticketsByAssignee = (new TicketsByAssignee())
+            ->add($ticket1)
+            ->add($ticket2)
+            ->add($ticket3);
+
+        self::assertEquals([
+            'assigneeKey1' => [$ticket1, $ticket2],
+            'assigneeKey2' => [$ticket3],
+        ], $ticketsByAssignee->list());
+    }
+
+    private function newJiraTicket(string $assigneeKey, string $ticketKey): JiraTicket
+    {
+        return new JiraTicket(
+            'The title',
+            $ticketKey,
+            new TicketStatus('In Progress', new DateTimeImmutable()),
+            new Assignee(
+                'assignee.name',
+                $assigneeKey,
+                'Full Name',
+                'any@example.com'
+            )
+        );
+    }
+}


### PR DESCRIPTION
# Description

I encapsulate the `tickets by assignee` into an object, instead of having them as a raw array.

I rename the previous class named `TicketsByAssignee` to `TicketsByAssigneeClient` because its responsibility is to communicate via HTTP and gets the tickets from a board in a particular status. 
Before, this same class was doing also the "grouping logic" (aka: grouping the tickets from different statuses by their assignee). So I decoupled this "grouping logic" into the new class that I named `TicketsByAssignee`.

I also changed the usages of `array $ticketsByAssignee` to `TicketsByAssignee $ticketsByAssignee`, and also `array $tickets` to `JiraTicket...$ticket` whenever is possible. 
