### PR TITLE
Fix slack message notification

### DIFF
--- a/examples/templates/slack-template.twig
+++ b/examples/templates/slack-template.twig
@@ -1,20 +1,20 @@
 {% set firstTicket = tickets | first %}
 {% set assignee = firstTicket.assignee %}
+{% set assigneeProfile = "https://" ~ companyName ~ ".atlassian.net/jira/people/" ~ assignee.accountId %}
 
 {% if assignee.accountId %}
-    {% set salutation = "Hey, " ~ assignee.displayName ~ " (" ~ assignee.accountId ~ ")" %}
+    {% set assigneeProfile = "https://" ~ companyName ~ ".atlassian.net/jira/people/" ~ assignee.accountId %}
+    Hey <{{ assigneeProfile }}|{{ assignee.displayName }}>, please have a look
 {% else %}
-    {% set salutation = 'Hey Team' %}
+    Hey Team, please have a look
 {% endif %}
 
-{{ salutation }}, please have a look
 
 {% for ticket in tickets %}
-    {% set status = ticket.status %}
-    {% set daysDiff = status.changeDate.diff(now).days %}
-    {% set url = "https://" ~ companyName ~ ".atlassian.net/browse/" ~ ticket.key %}
-    {% set dayWord = (daysDiff > 1) ? 'days' : 'day' %}
-
+{% set status = ticket.status %}
+{% set daysDiff = status.changeDate.diff(now).days %}
+{% set url = "https://" ~ companyName ~ ".atlassian.net/browse/" ~ ticket.key %}
+{% set dayWord = (daysDiff > 1) ? 'days' : 'day' %}
 > [<{{ url }}|{{ ticket.key }}>] {{ ticket.title | raw }}
 {{ ticket.customFields['StoryPoints'] }} *SP* | *Current status*: {{ status.name }} since {{ daysDiff }} {{ dayWord }}
 {% endfor %}

--- a/examples/templates/slack-template.twig
+++ b/examples/templates/slack-template.twig
@@ -1,8 +1,8 @@
 {% set firstTicket = tickets | first %}
 {% set assignee = firstTicket.assignee %}
 
-{% if assignee.key %}
-    {% set salutation = "Hey, " ~ assignee.displayName ~ "(" ~ assignee.name ~ ")" %}
+{% if assignee.accountId %}
+    {% set salutation = "Hey, " ~ assignee.displayName ~ " (" ~ assignee.accountId ~ ")" %}
 {% else %}
     {% set salutation = 'Hey Team' %}
 {% endif %}

--- a/examples/templates/slack-template.twig
+++ b/examples/templates/slack-template.twig
@@ -1,6 +1,5 @@
 {% set firstTicket = tickets | first %}
 {% set assignee = firstTicket.assignee %}
-{% set assigneeProfile = "https://" ~ companyName ~ ".atlassian.net/jira/people/" ~ assignee.accountId %}
 
 {% if assignee.accountId %}
     {% set assigneeProfile = "https://" ~ companyName ~ ".atlassian.net/jira/people/" ~ assignee.accountId %}


### PR DESCRIPTION
# Description

The slack message displayed always the `Hey Team` message even when the ticket was assigned to a user.
The problem was caused due to the Jira API changes.

It has been fixed to display something like:
----
Hey Team, please have a look
**|** [XYZ-1] Ticket name #1
**YY | Current status: To Do since Z days**

Hey [userName](#), please have a look
**|** [XYZ-3] Ticket name #3
**YY | Current status: To Do since Z days**
**|** [XYZ-4] Ticket name #4
**YY | Current status: In Progress since Z days**
